### PR TITLE
#251 Кнопка запуска выделенных тестов установлена кнопкой по умолчанию

### DIFF
--- a/exts/yaxunit/src/DataProcessors/ЮТЮнитТесты/Forms/Основная/Form.form
+++ b/exts/yaxunit/src/DataProcessors/ЮТЮнитТесты/Forms/Основная/Form.form
@@ -132,6 +132,7 @@
           </extendedTooltip>
           <commandName>Form.Command.ЗапуститьВыделенныеТесты</commandName>
           <representation>Auto</representation>
+          <defaultButton>true</defaultButton>
           <autoMaxWidth>true</autoMaxWidth>
           <autoMaxHeight>true</autoMaxHeight>
           <placementArea>UserCmds</placementArea>


### PR DESCRIPTION
Кнопка запуска выделенных тестов установлена кнопкой по умолчанию.
Теперь запускается через типовое сокращение `Ctrl + Enter`.